### PR TITLE
fix#31:Handle external context received by NewApp

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -51,5 +51,8 @@ func main() {
 		}()
 	}
 
-	app.NewApp(context.Background(), cfg).Run()
+	if err := app.NewApp(context.Background(), cfg).Run(); err != nil {
+		log.Print("Unable to start app")
+		return
+	}
 }


### PR DESCRIPTION
What does this PR do?

This PR addresses issue #31 by ensuring that if the application errors out during startup, it will log the error and return appropriately.
Fix #31 